### PR TITLE
Fix the conflict with X11

### DIFF
--- a/olcPGEX_FrostUI.h
+++ b/olcPGEX_FrostUI.h
@@ -517,7 +517,7 @@ namespace olc
         };
 
         enum class TextKey {
-            None = -1,
+            NONE = -1,
             A = 0, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
             Num0, Num1, Num2, Num3, Num4, Num5, Num6, Num7, Num8, Num9,
             LBracket, RBracket, Semicolon, Comma, Period, Quote, ForwardSlash, BackwardSlash,
@@ -2748,13 +2748,13 @@ namespace olc
                 return i;
             }
         }
-        return static_cast<int>(TextKey::None);
+        return static_cast<int>(TextKey::NONE);
     }
 
     std::string FUI_Inputfield::get_char_from_id(olc::PixelGameEngine* pge)
     {
         int index = get_char_id(pge);
-        if (index == static_cast<int>(TextKey::None)) return "";
+        if (index == static_cast<int>(TextKey::NONE)) return "";
 
         if (pge->GetKey(olc::SHIFT).bHeld) {
             return std::string(1, text_shift[index]);


### PR DESCRIPTION
So, this is a bit of an edge case.
I had a hard time compiling on Arch, gcc just kept yelling.
So, there is a conflict with X11 targets.

On X11 targets, PGE includes `X11/X.h` header, which has a macro defining `None` as `0`
Since that is a reserved identifier, we can't use `None`. However `NONE` is available.

This also makes it more consistent with the keys in `olc::FUI_Inputfield::State` and `olc::Key`, which both use `NONE`